### PR TITLE
[Enhancement][README] Add installation command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ User interface for SaltCellar based on Patternfly [![Patternfly][pf-logo]][patte
 2. Clone repo, and open a terminal in the base of this project.
 3. Run the command `yarn` to install all the dependencies.
 
+### Install SaltCellar UI
+```
+yarn install
+```
+
 ### Running Development Server
 ```
 yarn start


### PR DESCRIPTION
You need execute yarn install before yarn start

```bash
~/.../salt/UI-1 (add_patternfly)$ yarn start
yarn run v1.3.2
$ webpack-dev-server
Webpack config /home/alberto/Projects/salt/UI-1/config/webpack/development.js not found, please run 'bundle exec rails webpacker:install' to install webpacker with default configs or add the missing config file for your custom environment.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

```